### PR TITLE
Fix shader/uniform order

### DIFF
--- a/pkg/image/view.go
+++ b/pkg/image/view.go
@@ -101,15 +101,16 @@ func NewView(area *sdl.Rect, fileName string, bbComms chan<- comms.Image, toolCo
 	iv.area = area
 	iv.bbComms = bbComms
 	iv.toolComms = toolComms
-	if err = iv.LoadFromFile(fileName); err != nil {
-		return nil, err
-	}
 
 	if iv.programID, err = gfx.CreateShaderProgram(gfx.VertexShaderSource, gfx.CheckerShaderFragment); err != nil {
 		return nil, err
 	}
 
 	if iv.selProgramID, err = gfx.CreateShaderProgram(gfx.OutlineVsh, gfx.OutlineFsh); err != nil {
+		return nil, err
+	}
+
+	if err = iv.LoadFromFile(fileName); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The bug where selection outlining would not work on startup was caused by trying to upload the origDims and mult uniforms in the LoadFromFile function before the shader programs were created. This means that those program IDs were just 0, so when we did bind(programID) it was just binding to zero and not finding the variable locations in the shaders to upload to. This highlights how we have a lack of OpenGL error handling.