### PR TITLE
Upgrade github.com/veandco/go-sdl2 to 0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/jcmuller/gozenity v0.0.1
 	github.com/kroppt/Int32Set v0.0.0-20190617043009-95c3ce40003c
 	github.com/kroppt/winfileask v0.0.0-20200406172824-13c3807ac64f
-	github.com/veandco/go-sdl2 v0.3.3
+	github.com/veandco/go-sdl2 v0.4.4
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/kroppt/winfileask v0.0.0-20200406172824-13c3807ac64f h1:/CnqsfHLkghAE
 github.com/kroppt/winfileask v0.0.0-20200406172824-13c3807ac64f/go.mod h1:biYF1MwJ7dNUHE4F6GtL67wQu1sFJdMUxG+PbKQQyGU=
 github.com/veandco/go-sdl2 v0.3.3 h1:4/TirgB2MQ7oww3pM3Yfgf1YbChMlAQAmiCPe5koK0I=
 github.com/veandco/go-sdl2 v0.3.3/go.mod h1:FB+kTpX9YTE+urhYiClnRzpOXbiWgaU3+5F2AB78DPg=
+github.com/veandco/go-sdl2 v0.4.4 h1:coOJGftOdvNvGoUIZmm4XD+ZRQF4mg9ZVHmH3/42zFQ=
+github.com/veandco/go-sdl2 v0.4.4/go.mod h1:FB+kTpX9YTE+urhYiClnRzpOXbiWgaU3+5F2AB78DPg=
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1 h1:5h3ngYt7+vXCDZCup/HkCQgW5XwmSvR/nA2JmJ0RErg=
 golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
This allows users to build without having SDL2 and some of its dependencies installed. This would be done using `-tags static` as a build flag.
For static builds, a few dependencies will still need to be installed in static builds, but the following would not need to be installed:
- freetype
- jpeg
- mpg123
- ogg
- png
- SDL2{,_gfx,_image,main,_mixer,_ttf}
- vorbis
- z

Building this way on Actions didn't seem very worthwhile, as the build time for the project is unchanged.