### PR TITLE
Refactor Uniform Uploads

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -234,6 +234,10 @@ func (app *Application) PostEventActions() {
 
 	app.win.GLSwap()
 	perf.EndFrame()
+
+	for glErr := gl.GetError(); glErr != gl.NO_ERROR; glErr = gl.GetError() {
+		log.Warnf("OpenGL error: %v", glErr)
+	}
 	// wait until frametime has passed
 	<-app.ticker.C
 }

--- a/pkg/app/bottomBar.go
+++ b/pkg/app/bottomBar.go
@@ -50,23 +50,17 @@ func NewBottomBar(area *sdl.Rect, comms <-chan comms.Image, cfg *config.Config) 
 	barColor := [4]float32{0.5, 0.5, 0.5, 1.0}
 	textColor := [4]float32{1.0, 1.0, 1.0, 1.0}
 
-	barColorID := gl.GetUniformLocation(backProgramID, &[]byte("uni_color\x00")[0])
-	gl.UseProgram(backProgramID)
-	gl.Uniform4f(barColorID, barColor[0], barColor[1], barColor[2], barColor[3])
-
-	uniScrSizeID := gl.GetUniformLocation(textProgramID, &[]byte("screen_size\x00")[0])
-	texSizeID := gl.GetUniformLocation(textProgramID, &[]byte("tex_size\x00")[0])
-	textColorID := gl.GetUniformLocation(textProgramID, &[]byte("text_color\x00")[0])
+	gfx.UploadUniform(backProgramID, "uni_color", barColor[0], barColor[1], barColor[2], barColor[3])
 
 	var texSheetWidth, texSheetHeight int32
 	gl.BindTexture(gl.TEXTURE_2D, fnt.TextureID())
 	gl.GetTexLevelParameteriv(gl.TEXTURE_2D, 0, gl.TEXTURE_WIDTH, &texSheetWidth)
 	gl.GetTexLevelParameteriv(gl.TEXTURE_2D, 0, gl.TEXTURE_HEIGHT, &texSheetHeight)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
-	gl.UseProgram(textProgramID)
-	gl.Uniform2f(texSizeID, float32(texSheetWidth), float32(texSheetHeight))
-	gl.Uniform2f(uniScrSizeID, float32(cfg.ScreenWidth), float32(cfg.ScreenHeight))
-	gl.Uniform4f(textColorID, textColor[0], textColor[1], textColor[2], textColor[3])
+
+	gfx.UploadUniform(textProgramID, "screen_size", float32(cfg.ScreenWidth), float32(cfg.ScreenHeight))
+	gfx.UploadUniform(textProgramID, "tex_size", float32(texSheetWidth), float32(texSheetHeight))
+	gfx.UploadUniform(textProgramID, "text_color", textColor[0], textColor[1], textColor[2], textColor[3])
 
 	backTriangles := []float32{
 		-1.0, -1.0, // bottom-left
@@ -109,18 +103,12 @@ func NewBottomBar(area *sdl.Rect, comms <-chan comms.Image, cfg *config.Config) 
 
 // SetBackgroundColor sets the color for the bottom bar's background texture
 func (bb *BottomBar) SetBackgroundColor(color []float32) {
-	uniformID := gl.GetUniformLocation(bb.backProgramID, &[]byte("uni_color\x00")[0])
-	gl.UseProgram(bb.backProgramID)
-	gl.Uniform4f(uniformID, float32(color[0]), float32(color[1]), float32(color[2]), float32(color[3]))
-	gl.UseProgram(0)
+	gfx.UploadUniform(bb.backProgramID, "uni_color", float32(color[0]), float32(color[1]), float32(color[2]), float32(color[3]))
 }
 
 // SetTextColor sets the color for the bottom bar's text elements
 func (bb *BottomBar) SetTextColor(color []float32) {
-	uniformID := gl.GetUniformLocation(bb.textProgramID, &[]byte("text_color\x00")[0])
-	gl.UseProgram(bb.textProgramID)
-	gl.Uniform4f(uniformID, float32(color[0]), float32(color[1]), float32(color[2]), float32(color[3]))
-	gl.UseProgram(0)
+	gfx.UploadUniform(bb.textProgramID, "text_color", float32(color[0]), float32(color[1]), float32(color[2]), float32(color[3]))
 }
 
 // Destroy frees all assets obtained by the ui.Component
@@ -219,10 +207,7 @@ func (bb *BottomBar) OnResize(x, y int32) {
 	bb.area.W += x
 	bb.area.Y += y
 
-	uniformID := gl.GetUniformLocation(bb.textProgramID, &[]byte("screen_size\x00")[0])
-	gl.UseProgram(bb.textProgramID)
-	gl.Uniform2f(uniformID, float32(bb.cfg.ScreenWidth), float32(bb.cfg.ScreenHeight))
-	gl.UseProgram(0)
+	gfx.UploadUniform(bb.textProgramID, "screen_size", float32(bb.cfg.ScreenWidth), float32(bb.cfg.ScreenHeight))
 }
 
 // String returns the name of the component type

--- a/pkg/gfx/gfx.go
+++ b/pkg/gfx/gfx.go
@@ -101,7 +101,7 @@ func compileShader(source string, shaderType uint32) (uint32, error) {
 func UploadUniform(programID uint32, uniformName string, data ...float32) {
 	uniformID := gl.GetUniformLocation(programID, &[]byte(uniformName + "\x00")[0])
 	if uniformID == -1 {
-		panic(fmt.Sprintf("\"%s\" is an invalid uniform name", uniformName))
+		log.Fatalf("\"%s\" is an invalid uniform name", uniformName)
 	}
 	gl.UseProgram(programID)
 	switch len(data) {
@@ -114,7 +114,7 @@ func UploadUniform(programID uint32, uniformName string, data ...float32) {
 	case 4:
 		gl.Uniform4f(uniformID, data[0], data[1], data[2], data[3])
 	default:
-		panic("Invalid number of arguments to uploadUniform")
+		log.Fatal("Invalid number of arguments to uploadUniform")
 	}
 	gl.UseProgram(0)
 }

--- a/pkg/gfx/gfx.go
+++ b/pkg/gfx/gfx.go
@@ -92,3 +92,29 @@ func compileShader(source string, shaderType uint32) (uint32, error) {
 
 	return shader, nil
 }
+
+// UploadUniform uploads float32 data in the given uniform variable
+// belonging to the given program ID.
+//
+// If data does not contain between 1 and 4 arguments (inclusive),
+// UploadUniform will panic.
+func UploadUniform(programID uint32, uniformName string, data ...float32) {
+	uniformID := gl.GetUniformLocation(programID, &[]byte(uniformName + "\x00")[0])
+	if uniformID == -1 {
+		panic(fmt.Sprintf("\"%s\" is an invalid uniform name", uniformName))
+	}
+	gl.UseProgram(programID)
+	switch len(data) {
+	case 1:
+		gl.Uniform1f(uniformID, data[0])
+	case 2:
+		gl.Uniform2f(uniformID, data[0], data[1])
+	case 3:
+		gl.Uniform3f(uniformID, data[0], data[1], data[2])
+	case 4:
+		gl.Uniform4f(uniformID, data[0], data[1], data[2], data[3])
+	default:
+		panic("Invalid number of arguments to uploadUniform")
+	}
+	gl.UseProgram(0)
+}

--- a/pkg/image/view.go
+++ b/pkg/image/view.go
@@ -56,10 +56,7 @@ func (iv *View) LoadFromFile(fileName string) error {
 	}
 	iv.origW = int32(width)
 	iv.origH = int32(height)
-	uniformID := gl.GetUniformLocation(iv.selProgramID, &[]byte("origDims\x00")[0])
-	gl.UseProgram(iv.selProgramID)
-	gl.Uniform2f(uniformID, float32(iv.origW), float32(iv.origH))
-	gl.UseProgram(0)
+	gfx.UploadUniform(iv.selProgramID, "origDims", float32(iv.origW), float32(iv.origH))
 
 	format := int32(gl.RGBA)
 	gl.DeleteTextures(1, &iv.textureID)
@@ -80,10 +77,7 @@ func (iv *View) LoadFromFile(fileName string) error {
 	}
 	iv.CenterImage()
 	iv.mult = 1.0
-	uniformID = gl.GetUniformLocation(iv.selProgramID, &[]byte("mult\x00")[0])
-	gl.UseProgram(iv.selProgramID)
-	gl.Uniform1f(uniformID, float32(iv.mult))
-	gl.UseProgram(0)
+	gfx.UploadUniform(iv.selProgramID, "mult", float32(iv.mult))
 
 	parts := strings.Split(fileName, string(os.PathSeparator))
 	iv.fileName = parts[len(parts)-1]
@@ -114,10 +108,7 @@ func NewView(area *sdl.Rect, fileName string, bbComms chan<- comms.Image, toolCo
 		return nil, err
 	}
 
-	uniformID := gl.GetUniformLocation(iv.programID, &[]byte("area\x00")[0])
-	gl.UseProgram(iv.programID)
-	gl.Uniform2f(uniformID, float32(iv.area.W), float32(iv.area.H))
-	gl.UseProgram(0)
+	gfx.UploadUniform(iv.programID, "area", float32(iv.area.W), float32(iv.area.H))
 
 	gl.GenBuffers(1, &iv.vboID)
 	gl.GenVertexArrays(1, &iv.vaoID)
@@ -255,10 +246,8 @@ func (iv *View) zoomIn() {
 	iv.canvas.H = int32(float64(iv.origH) * iv.mult)
 	iv.canvas.X = 2*iv.canvas.X - int32(math.Round(float64(iv.area.W)/2.0)) //iv.mouseLoc.x
 	iv.canvas.Y = 2*iv.canvas.Y - int32(math.Round(float64(iv.area.H)/2.0)) //iv.mouseLoc.y
-	uniformID := gl.GetUniformLocation(iv.selProgramID, &[]byte("mult\x00")[0])
-	gl.UseProgram(iv.selProgramID)
-	gl.Uniform1f(uniformID, float32(iv.mult))
-	gl.UseProgram(0)
+
+	gfx.UploadUniform(iv.selProgramID, "mult", float32(iv.mult))
 }
 
 func (iv *View) zoomOut() {
@@ -267,10 +256,8 @@ func (iv *View) zoomOut() {
 	iv.canvas.H = int32(float64(iv.origH) * iv.mult)
 	iv.canvas.X = int32(math.Round(float64(iv.canvas.X)/2.0 + float64(iv.area.W)/4.0)) //iv.mouseLoc.x/2
 	iv.canvas.Y = int32(math.Round(float64(iv.canvas.Y)/2.0 + float64(iv.area.H)/4.0)) //iv.mouseLoc.y/2
-	uniformID := gl.GetUniformLocation(iv.selProgramID, &[]byte("mult\x00")[0])
-	gl.UseProgram(iv.selProgramID)
-	gl.Uniform1f(uniformID, float32(iv.mult))
-	gl.UseProgram(0)
+
+	gfx.UploadUniform(iv.selProgramID, "mult", float32(iv.mult))
 }
 
 func (iv *View) CenterImage() {
@@ -377,10 +364,7 @@ func (iv *View) OnResize(x, y int32) {
 	iv.area.W += x
 	iv.area.H += y
 
-	uniformID := gl.GetUniformLocation(iv.programID, &[]byte("area\x00")[0])
-	gl.UseProgram(iv.programID)
-	gl.Uniform2f(uniformID, float32(iv.area.W), float32(iv.area.H))
-	gl.UseProgram(0)
+	gfx.UploadUniform(iv.programID, "area", float32(iv.area.W), float32(iv.area.H))
 
 	iv.CenterImage()
 }

--- a/pkg/menu/button.go
+++ b/pkg/menu/button.go
@@ -55,23 +55,17 @@ func NewButton(area *sdl.Rect, cfg *config.Config, text string, action func()) (
 	backColor := [4]float32{0.8392, 0.8118, 0.8118, 1.0}
 	textColor := [4]float32{0.0, 0.0, 0.0, 1.0}
 
-	backColorID := gl.GetUniformLocation(backProgramID, &[]byte("uni_color\x00")[0])
-	gl.UseProgram(backProgramID)
-	gl.Uniform4f(backColorID, backColor[0], backColor[1], backColor[2], backColor[3])
-
-	uniScrSizeID := gl.GetUniformLocation(textProgramID, &[]byte("screen_size\x00")[0])
-	texSizeID := gl.GetUniformLocation(textProgramID, &[]byte("tex_size\x00")[0])
-	textColorID := gl.GetUniformLocation(textProgramID, &[]byte("text_color\x00")[0])
+	gfx.UploadUniform(backProgramID, "uni_color", backColor[0], backColor[1], backColor[2], backColor[3])
 
 	var texSheetWidth, texSheetHeight int32
 	gl.BindTexture(gl.TEXTURE_2D, fnt.TextureID())
 	gl.GetTexLevelParameteriv(gl.TEXTURE_2D, 0, gl.TEXTURE_WIDTH, &texSheetWidth)
 	gl.GetTexLevelParameteriv(gl.TEXTURE_2D, 0, gl.TEXTURE_HEIGHT, &texSheetHeight)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
-	gl.UseProgram(textProgramID)
-	gl.Uniform2f(uniScrSizeID, float32(cfg.ScreenWidth), float32(cfg.ScreenHeight))
-	gl.Uniform2f(texSizeID, float32(texSheetWidth), float32(texSheetHeight))
-	gl.Uniform4f(textColorID, textColor[0], textColor[1], textColor[2], textColor[3])
+
+	gfx.UploadUniform(textProgramID, "screen_size", float32(cfg.ScreenWidth), float32(cfg.ScreenHeight))
+	gfx.UploadUniform(textProgramID, "tex_size", float32(texSheetWidth), float32(texSheetHeight))
+	gfx.UploadUniform(textProgramID, "text_color", textColor[0], textColor[1], textColor[2], textColor[3])
 
 	backTriangles := []float32{
 		-1.0, -1.0, // bottom-left
@@ -133,10 +127,7 @@ func NewButton(area *sdl.Rect, cfg *config.Config, text string, action func()) (
 // SetDefaultBackgroundColor changes the default background color
 func (b *Button) SetDefaultBackgroundColor(color [4]float32) {
 	b.defaultBackColor = color
-	backColorID := gl.GetUniformLocation(b.textProgramID, &[]byte("text_color\x00")[0])
-	gl.UseProgram(b.backProgramID)
-	gl.Uniform4f(backColorID, b.defaultBackColor[0], b.defaultBackColor[1], b.defaultBackColor[2], b.defaultBackColor[3])
-	gl.UseProgram(0)
+	gfx.UploadUniform(b.backProgramID, "text_color", b.defaultBackColor[0], b.defaultBackColor[1], b.defaultBackColor[2], b.defaultBackColor[3])
 }
 
 // SetHighlightBackgroundColor changes the highlight background color
@@ -147,10 +138,7 @@ func (b *Button) SetHighlightBackgroundColor(color [4]float32) {
 // SetDefaultTextColor changes the default text color
 func (b *Button) SetDefaultTextColor(color [4]float32) {
 	b.defaultTextColor = color
-	textColorID := gl.GetUniformLocation(b.textProgramID, &[]byte("text_color\x00")[0])
-	gl.UseProgram(b.textProgramID)
-	gl.Uniform4f(textColorID, b.defaultTextColor[0], b.defaultTextColor[1], b.defaultTextColor[2], b.defaultTextColor[3])
-	gl.UseProgram(0)
+	gfx.UploadUniform(b.textProgramID, "text_color", b.defaultTextColor[0], b.defaultTextColor[1], b.defaultTextColor[2], b.defaultTextColor[3])
 }
 
 // SetHighlightTextColor changes the highlight text color
@@ -211,13 +199,9 @@ func (b *Button) Render() {
 func (b *Button) OnEnter() {
 	b.hovering = true
 
-	backColorID := gl.GetUniformLocation(b.backProgramID, &[]byte("uni_color\x00")[0])
-	gl.UseProgram(b.backProgramID)
-	gl.Uniform4f(backColorID, b.highlightBackColor[0], b.highlightBackColor[1], b.highlightBackColor[2], b.highlightBackColor[3])
-	textColorID := gl.GetUniformLocation(b.textProgramID, &[]byte("text_color\x00")[0])
-	gl.UseProgram(b.textProgramID)
-	gl.Uniform4f(textColorID, b.highlightTextColor[0], b.highlightTextColor[1], b.highlightTextColor[2], b.highlightTextColor[3])
-	gl.UseProgram(0)
+	gfx.UploadUniform(b.backProgramID, "uni_color", b.highlightBackColor[0], b.highlightBackColor[1], b.highlightBackColor[2], b.highlightBackColor[3])
+
+	gfx.UploadUniform(b.textProgramID, "text_color", b.highlightTextColor[0], b.highlightTextColor[1], b.highlightTextColor[2], b.highlightTextColor[3])
 }
 
 // OnLeave is called when the cursor leaves the ui.Component's region
@@ -225,13 +209,8 @@ func (b *Button) OnLeave() {
 	b.hovering = false
 	b.pressed = false
 
-	backColorID := gl.GetUniformLocation(b.backProgramID, &[]byte("uni_color\x00")[0])
-	gl.UseProgram(b.backProgramID)
-	gl.Uniform4f(backColorID, b.defaultBackColor[0], b.defaultBackColor[1], b.defaultBackColor[2], b.defaultBackColor[3])
-	textColorID := gl.GetUniformLocation(b.textProgramID, &[]byte("text_color\x00")[0])
-	gl.UseProgram(b.textProgramID)
-	gl.Uniform4f(textColorID, b.defaultTextColor[0], b.defaultTextColor[1], b.defaultTextColor[2], b.defaultTextColor[3])
-	gl.UseProgram(0)
+	gfx.UploadUniform(b.backProgramID, "uni_color", b.defaultBackColor[0], b.defaultBackColor[1], b.defaultBackColor[2], b.defaultBackColor[3])
+	gfx.UploadUniform(b.textProgramID, "text_color", b.defaultTextColor[0], b.defaultTextColor[1], b.defaultTextColor[2], b.defaultTextColor[3])
 }
 
 // OnMotion is called when the cursor moves within the ui.Component's region
@@ -258,10 +237,7 @@ func (b *Button) OnClick(evt *sdl.MouseButtonEvent) bool {
 // OnResize is called when the user resizes the window
 func (b *Button) OnResize(x, y int32) {
 	// recompute text triangles
-	uniformID := gl.GetUniformLocation(b.textProgramID, &[]byte("screen_size\x00")[0])
-	gl.UseProgram(b.textProgramID)
-	gl.Uniform2f(uniformID, float32(b.cfg.ScreenWidth), float32(b.cfg.ScreenHeight))
-	gl.UseProgram(0)
+	gfx.UploadUniform(b.textProgramID, "screen_size", float32(b.cfg.ScreenWidth), float32(b.cfg.ScreenHeight))
 
 	pos := sdl.Point{X: b.area.X + b.area.W/2, Y: b.cfg.ScreenHeight - b.area.Y - b.area.H/2}
 	align := ui.Align{V: ui.AlignMiddle, H: ui.AlignCenter}


### PR DESCRIPTION
These changes consolidate duplicated uniform upload code to make the OpenGL code more readable, reduce the likelihood of introduce hard-to-debug errors (like forgetting C-string terminator '\x00' at the end of variable name), and add improved error detection.