### PR TITLE
Add project saving and loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,10 +112,12 @@ func main() {
 	var perform bool
 	var quiet bool
 	var file string
+	var project string
 	flag.Usage = func() {
 		fmt.Fprintln(flag.CommandLine.Output(), "Usage:")
 		fmt.Fprintf(flag.CommandLine.Output(), "  %v [OPTIONS]\n", filepath.Base(os.Args[0]))
-		fmt.Fprintln(flag.CommandLine.Output(), "  Specify a file name with -file to open immediately.")
+		fmt.Fprintln(flag.CommandLine.Output(), "  Specify a file name with -file to open image as a layer.")
+		fmt.Fprintln(flag.CommandLine.Output(), "  Specify a project file (.tabula) with -project.")
 		fmt.Fprintln(flag.CommandLine.Output(), "  Otherwise, an open file dialog will be used, if supported.")
 		fmt.Fprintln(flag.CommandLine.Output(), "\nOptions:")
 		flag.PrintDefaults()
@@ -123,6 +125,7 @@ func main() {
 	flag.BoolVar(&color, "color", true, "colorize the output logs")
 	flag.BoolVar(&debug, "debug", false, "show debug logging")
 	flag.StringVar(&file, "file", "", "name of the file to open without prompt")
+	flag.StringVar(&project, "project", "", "name of the project file (.tabula) to open")
 	flag.IntVar(&fps, "fps", 144, "the frames per second to render at")
 	flag.IntVar(&height, "height", 720, "the initial height of the window")
 	flag.BoolVar(&info, "info", true, "show info logging")
@@ -160,6 +163,7 @@ func main() {
 
 	log.Debugf("args: [ %v ]", strings.Join(flag.Args(), ", "))
 	log.Debugf("file option: \"%v\"", file)
+	log.Debugf("project option: \"%v\"", project)
 	log.Debugf("enabled loggers: %v", strings.Join(loggers, ", "))
 	log.Debugf("output colorized: %v", color)
 
@@ -187,7 +191,7 @@ func main() {
 		log.Warnf("framerate %v not within set refresh rate range %v-%v", fps, lowHz, highHz)
 	}
 
-	app := app.New(file, win, cfg)
+	app := app.New(file, project, win, cfg)
 	app.Start()
 
 	for app.Running() {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -117,7 +117,7 @@ func New(fileName, project string, win *sdl.Window, cfg *config.Config) *Applica
 					Text: "Save Project",
 					Action: func() {
 						go func() {
-							newFileName, err := util.OpenFileDialog(win)
+							newFileName, err := util.SaveFileDialog(win)
 							if err != nil {
 								log.Warn(err)
 								return

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -30,14 +30,8 @@ type Application struct {
 }
 
 // New returns a newly instantiated application state struct
-func New(fileName string, win *sdl.Window, cfg *config.Config) *Application {
+func New(fileName, project string, win *sdl.Window, cfg *config.Config) *Application {
 	var err error
-	if fileName == "" {
-		log.Info("Using file dialog to get file name")
-		if fileName, err = util.OpenFileDialog(win); err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	imageViewArea := sdl.Rect{
 		X: 0,
@@ -60,11 +54,19 @@ func New(fileName string, win *sdl.Window, cfg *config.Config) *Application {
 	if err != nil {
 		log.Fatal(err)
 	}
-	tex, err := gfx.NewTextureFromFile(fileName)
-	if err != nil {
-		log.Fatal(err)
+
+	if fileName != "" {
+		tex, err := gfx.NewTextureFromFile(fileName)
+		if err != nil {
+			log.Fatal(err)
+		}
+		iv.AddLayer(tex)
 	}
-	iv.AddLayer(tex)
+	if project != "" {
+		if err = iv.LoadProject(project); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	bottomBar, err := NewBottomBar(bottomBarArea, bottomBarComms, cfg)
 	if err != nil {
@@ -76,7 +78,7 @@ func New(fileName string, win *sdl.Window, cfg *config.Config) *Application {
 			Text: "File",
 			Children: []menu.Definition{
 				{
-					Text: "Open",
+					Text: "Open as Layer",
 					Action: func() {
 						newFileName, err := util.OpenFileDialog(win)
 						if err != nil {
@@ -95,7 +97,7 @@ func New(fileName string, win *sdl.Window, cfg *config.Config) *Application {
 					},
 				},
 				{
-					Text: "Save As",
+					Text: "Export Canvas",
 					Action: func() {
 						newFileName, err := util.SaveFileDialog(win)
 						if err != nil {
@@ -105,6 +107,42 @@ func New(fileName string, win *sdl.Window, cfg *config.Config) *Application {
 						go func() {
 							actionComms <- func() {
 								if err := iv.WriteToFile(newFileName); err != nil {
+									log.Fatal(err)
+								}
+							}
+						}()
+					},
+				},
+				{
+					Text: "Save Project",
+					Action: func() {
+						go func() {
+							newFileName, err := util.OpenFileDialog(win)
+							if err != nil {
+								log.Warn(err)
+								return
+							}
+							actionComms <- func() {
+								err = iv.SaveProject(newFileName)
+								if err != nil {
+									log.Fatal(err)
+								}
+							}
+						}()
+					},
+				},
+				{
+					Text: "Load Project",
+					Action: func() {
+						go func() {
+							newFileName, err := util.OpenFileDialog(win)
+							if err != nil {
+								log.Warn(err)
+								return
+							}
+							actionComms <- func() {
+								err = iv.LoadProject(newFileName)
+								if err != nil {
 									log.Fatal(err)
 								}
 							}

--- a/pkg/gfx/framebuffer.go
+++ b/pkg/gfx/framebuffer.go
@@ -12,6 +12,8 @@ type FrameBuffer struct {
 
 const ErrFrameBuffer log.ConstErr = "incomplete framebuffer"
 
+// NewFrameBuffer creates an FBO of the specified size that renders to
+// a texture
 func NewFrameBuffer(width, height int32) (FrameBuffer, error) {
 	var fb FrameBuffer
 	var err error
@@ -38,10 +40,12 @@ func (fb FrameBuffer) GetTexture() Texture {
 	return fb.tex
 }
 
+// Bind tells OpenGL to use this framebuffer instead of the default one
 func (fb FrameBuffer) Bind() {
 	gl.BindFramebuffer(gl.FRAMEBUFFER, fb.id)
 }
 
+// Unbind tells OpenGL to stop rendering to this FBO and go back to the screen
 func (fb FrameBuffer) Unbind() {
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
 }

--- a/pkg/gfx/program.go
+++ b/pkg/gfx/program.go
@@ -74,7 +74,7 @@ func (p Program) Unbind() {
 	gl.UseProgram(0)
 }
 
-// Delete tells OpenGL to delete the program ID
+// Destroy destroys OpenGL assets associated with the Shader
 func (p Program) Destroy() {
 	gl.DeleteProgram(p.id)
 }

--- a/pkg/gfx/texture.go
+++ b/pkg/gfx/texture.go
@@ -21,6 +21,9 @@ type Texture struct {
 	format uint32
 }
 
+// NewTextureFromFile creates a new Texture, loading data from fileName
+// with the assumption that it is an image that can be converted to RGBA
+// (alpha is black for jpegs)
 func NewTextureFromFile(fileName string) (Texture, error) {
 	in, err := os.Open(fileName)
 	if err != nil {
@@ -64,6 +67,9 @@ func NewTextureFromFile(fileName string) (Texture, error) {
 	return t, err
 }
 
+// NewTexture creates a Texture object that wraps the OpenGL texture functions
+// alignment is in bytes and is passed to gl.PixelStorei() for unpacking
+// format example: gl.RGBA
 func NewTexture(width, height int32, data []byte, format int, alignment int32) (Texture, error) {
 	t := Texture{
 		width:  width,
@@ -85,6 +91,7 @@ func NewTexture(width, height int32, data []byte, format int, alignment int32) (
 	return t, nil
 }
 
+// SetParameter wraps gl.TexParameteri()
 func (t Texture) SetParameter(paramName uint32, param int32) {
 	t.Bind()
 	gl.TexParameteri(gl.TEXTURE_2D, paramName, param)
@@ -94,6 +101,7 @@ func (t Texture) SetParameter(paramName uint32, param int32) {
 // ErrCoordOutOfRange indicates that given coordinates are out of range
 const ErrCoordOutOfRange log.ConstErr = "coordinates out of range"
 
+// SetPixel sets a texel of a texture at coordinate p to color col
 func (t Texture) SetPixel(p sdl.Point, col color.RGBA) error {
 	if p.X < 0 || p.Y < 0 || p.X >= t.width || p.Y >= t.height {
 		return fmt.Errorf("setPixel(%v, %v): %w", p.X, p.Y, ErrCoordOutOfRange)
@@ -107,6 +115,7 @@ func (t Texture) SetPixel(p sdl.Point, col color.RGBA) error {
 	return nil
 }
 
+// GetData returns a byte slice of all the texture data
 func (t Texture) GetData() []byte {
 	// TODO do this in batches/stream to avoid memory limitations
 	var data = make([]byte, t.width*t.height*4)
@@ -116,6 +125,8 @@ func (t Texture) GetData() []byte {
 	return data
 }
 
+// GetSubData returns a portion of the texture data starting at x, y and going
+// w in the x diretion and h in the y direction
 func (t Texture) GetSubData(x, y, w, h int32) []byte {
 	// TODO do this in batches/stream to avoid memory limitations
 	var data = make([]byte, w*h*4)
@@ -141,6 +152,7 @@ func (t Texture) GetHeight() int32 {
 	return t.height
 }
 
+// Destroy destroys OpenGL assets associated with the Texture
 func (t Texture) Destroy() {
 	gl.DeleteTextures(1, &t.id)
 }

--- a/pkg/image/layer.go
+++ b/pkg/image/layer.go
@@ -95,11 +95,13 @@ func (l Layer) Render(view sdl.FRect) {
 	l.texture.Unbind()
 }
 
+// Destroy destroys OpenGL assets associated with the Layer
 func (l Layer) Destroy() {
 	l.buffer.Destroy()
 	l.texture.Destroy()
 }
 
+// MarshalBinary fulfills a requirement for gob to encode Layer
 func (l Layer) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
 	var err error
@@ -113,6 +115,7 @@ func (l Layer) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// UnmarshalBinary fulfills a requirement for gob to decode Layer
 func (l *Layer) UnmarshalBinary(data []byte) error {
 	var err error
 	dec := gob.NewDecoder(bytes.NewReader(data))

--- a/pkg/image/view.go
+++ b/pkg/image/view.go
@@ -179,6 +179,8 @@ func (iv *View) RenderCanvas() {
 
 const maxZoom = 8
 
+// updateView updates the view rectangle according to the zoom multiplier,
+// while maintaining the current pan
 func (iv *View) updateView() {
 	frac := float32(math.Pow(2, float64(-iv.mult)))
 	newView := sdl.FRect{}
@@ -191,6 +193,7 @@ func (iv *View) updateView() {
 	iv.program.UploadUniform("area", float32(iv.view.W), float32(iv.view.H))
 }
 
+// CenterCanvas updates the view so the canvas is in the center of the window
 func (iv *View) CenterCanvas() {
 	iv.view = sdl.FRect{
 		X: float32(iv.canvas.X) - (float32(iv.area.W)/2 - float32(iv.canvas.W)/2),
@@ -203,6 +206,8 @@ func (iv *View) CenterCanvas() {
 	iv.program.UploadUniform("area", float32(iv.view.W), float32(iv.view.H))
 }
 
+// setPixel sets the currently hovered texel of the selected layer
+// to the specified color
 func (iv *View) setPixel(p sdl.Point, col color.RGBA) error {
 	if iv.selLayer != nil {
 		p.X -= iv.selLayer.area.X
@@ -316,6 +321,8 @@ func (iv *View) OnScroll(evt *sdl.MouseWheelEvent) bool {
 	return true
 }
 
+// selectLayer sets the currently selected layer to nil, and sets the layer
+// that the mouse is currently hovering over, if any.
 func (iv *View) selectLayer() {
 	iv.selLayer = nil
 	for i := len(iv.layers) - 1; i >= 0; i-- {
@@ -357,7 +364,8 @@ func (iv *View) String() string {
 // ErrWriteFormat indicates that an unsupported image format was trying to be written to
 const ErrWriteFormat log.ConstErr = "unsupported image format"
 
-// WriteToFile writes the image data stored in the OpenGL texture to a file specified by fileName
+// WriteToFile uses an OpenGL Frame Buffer Object to render the data in the canvas
+// to a texture, and then write the data in that texture to the specified file
 func (iv *View) WriteToFile(fileName string) error {
 	sw := util.Start()
 	// TODO after canvas figured out
@@ -417,6 +425,8 @@ type Project struct {
 
 const ErrInvalidFormat log.ConstErr = "invalid project file (not .tabula)"
 
+// SaveProject saves the relevant project data at the specified file location
+// in a compressed format. The fileName must end with '.tabula'
 func (iv *View) SaveProject(fileName string) error {
 	sw := util.Start()
 	var ext string
@@ -454,6 +464,9 @@ func (iv *View) SaveProject(fileName string) error {
 	return nil
 }
 
+// LoadProject loads the project data at the specified file location,
+// decompresses and decodes the data and populates the relevant fields in
+// the image view. The fileName must end with '.tabula'
 func (iv *View) LoadProject(fileName string) error {
 	sw := util.Start()
 	var err error

--- a/pkg/image/view.go
+++ b/pkg/image/view.go
@@ -162,7 +162,7 @@ func (iv *View) Render() {
 
 // RenderCanvas draws what is on the canvas or area, whichever is larger
 func (iv *View) RenderCanvas() {
-
+	sw := util.Start()
 	iv.program.UploadUniform("area", float32(iv.canvas.W), float32(iv.canvas.H))
 	// gl viewport 0, 0 is bottom left
 	gl.Viewport(0, 0, iv.canvas.W, iv.canvas.H)
@@ -179,6 +179,7 @@ func (iv *View) RenderCanvas() {
 	iv.program.Unbind()
 
 	iv.updateView()
+	sw.Stop("RenderCanvas")
 }
 
 const maxZoom = 8
@@ -363,6 +364,7 @@ const ErrWriteFormat log.ConstErr = "unsupported image format"
 
 // WriteToFile writes the image data stored in the OpenGL texture to a file specified by fileName
 func (iv *View) WriteToFile(fileName string) error {
+	sw := util.Start()
 	// TODO after canvas figured out
 	w, h := iv.canvas.W, iv.canvas.H
 
@@ -405,6 +407,8 @@ func (iv *View) WriteToFile(fileName string) error {
 	default:
 		return fmt.Errorf("writing to file extension %v: %w", ext, ErrWriteFormat)
 	}
+
+	sw.Stop("WriteToFile")
 	return nil
 }
 
@@ -419,6 +423,7 @@ type Project struct {
 const ErrInvalidFormat log.ConstErr = "invalid project file (not .tabula)"
 
 func (iv *View) SaveProject(fileName string) error {
+	sw := util.Start()
 	var ext string
 	if ext = filepath.Ext(fileName); ext != ".tabula" {
 		return fmt.Errorf("%w: %v", ErrInvalidFormat, fileName)
@@ -450,10 +455,12 @@ func (iv *View) SaveProject(fileName string) error {
 	defer zw.Close()
 
 	iv.projName = proj.ProjName
+	sw.Stop("SaveProject")
 	return nil
 }
 
 func (iv *View) LoadProject(fileName string) error {
+	sw := util.Start()
 	var err error
 	var in *os.File
 	if in, err = os.Open(fileName); err != nil {
@@ -484,5 +491,6 @@ func (iv *View) LoadProject(fileName string) error {
 	iv.projName = proj.ProjName
 
 	iv.updateView()
+	sw.Stop("LoadProject")
 	return nil
 }

--- a/pkg/image/view.go
+++ b/pkg/image/view.go
@@ -169,12 +169,7 @@ func (iv *View) RenderCanvas() {
 
 	iv.program.Bind()
 	for _, layer := range iv.layers {
-		layer.Render(sdl.FRect{
-			X: float32(iv.canvas.X),
-			Y: float32(iv.canvas.Y),
-			W: float32(iv.canvas.W),
-			H: float32(iv.canvas.H),
-		})
+		layer.Render(ui.RectToFRect(iv.canvas))
 	}
 	iv.program.Unbind()
 

--- a/pkg/image/view.go
+++ b/pkg/image/view.go
@@ -45,6 +45,7 @@ type View struct {
 	toolComms   <-chan Tool
 	checkerProg gfx.Program
 	program     gfx.Program
+	projName    string
 }
 
 func (iv *View) AddLayer(tex gfx.Texture) {
@@ -106,6 +107,7 @@ func NewView(area sdl.Rect, bbComms chan<- comms.Image, toolComms <-chan Tool, c
 	iv.activeTool = &EmptyTool{}
 
 	iv.CenterCanvas()
+	iv.projName = "New Project"
 
 	return iv, nil
 }
@@ -128,7 +130,7 @@ func (iv *View) InBoundary(pt sdl.Point) bool {
 func (iv *View) Render() {
 	sw := util.Start()
 	go func() {
-		iv.bbComms <- comms.Image{FileName: "layer", MousePix: iv.mousePix, Mult: iv.mult}
+		iv.bbComms <- comms.Image{FileName: iv.projName, MousePix: iv.mousePix, Mult: iv.mult}
 	}()
 
 	// TODO selection outline
@@ -449,7 +451,7 @@ func (iv *View) SaveProject(fileName string) error {
 	if err != nil {
 		return err
 	}
-
+	iv.projName = filepath.Base(fileName)
 	return nil
 }
 
@@ -502,6 +504,6 @@ func (iv *View) LoadProject(fileName string) error {
 	}
 
 	iv.updateView()
-
+	iv.projName = filepath.Base(fileName)
 	return nil
 }


### PR DESCRIPTION
These changes implement the notion of a "project" that can be saved or loaded. Your project includes where your view is currently positioned (zoom, pan), the layer texture data, where the layers have been dragged to, etc. The idea is that if you save your project, close the program, and then reopen it with the project (via the Load Project button, or with the new -project command line option), it should appear exactly the way you left it. Saving and loading uses gob for organization, and zlib for compression of the data. The project file extension that you need to use is `.tabula`